### PR TITLE
Fix building issues

### DIFF
--- a/BMI/build.gradle
+++ b/BMI/build.gradle
@@ -20,14 +20,9 @@ dependencies {
     compile 'com.android.support:appcompat-v7:+'
 }
 
-buildscript {
-    repositories {
-        mavenCentral()
-        maven {
-            url 'https://plugins.gradle.org/m2/'
-        }
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+repositories {
+    jcenter()
+    maven {
+        url 'https://maven.google.com'
     }
 }

--- a/BMI/build.gradle
+++ b/BMI/build.gradle
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:+'
+    compile 'com.android.support:appcompat-v7:26.0.2'
 }
 
 repositories {

--- a/BMI/src/main/java/com/zola/bmi/BMIMain.java
+++ b/BMI/src/main/java/com/zola/bmi/BMIMain.java
@@ -1,6 +1,6 @@
 package com.zola.bmi;
 
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v4.app.Fragment;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -13,7 +13,7 @@ import android.widget.TextView;
 import java.text.DecimalFormat;
 
 
-public class BMIMain extends ActionBarActivity {
+public class BMIMain extends AppCompatActivity {
 
     //private Spinner weightSpinner, heightSpinner;
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,10 @@
 
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
+        maven {
+            url 'https://maven.google.com'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'


### PR DESCRIPTION
Those changes fix BMI Calculator compilation from the command line (this case includes F-Droid build server):

    gradle assembleRelease

Also note that before making a new release you need to bump `versionCode`, not only `versionName`. Otherwise Android considers new build the same as old one and will not upgrade it.